### PR TITLE
Fix PyPI cannot render markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jqdatasdk.get_price("000001.XSHE", start_date="2017-01-01", end_date="2017-12-31
 结果显示：
 
 ```
-             open  close   high    low       volume         money
+.            open  close   high    low       volume         money
 2017-01-03   8.98   9.03   9.05   8.96   46650858.0  4.205952e+08
 2017-01-04   9.02   9.03   9.05   9.01   45584521.0  4.115034e+08
 2017-01-05   9.04   9.04   9.05   9.02   34936662.0  3.157697e+08

--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,10 @@ except ImportError:
     # for pip <= 9.0.3
     from pip.req import parse_requirements
 
-
 from setuptools import (
     find_packages,
     setup,
 )
-
 
 with open(join(dirname(__file__), 'VERSION.txt'), 'rb') as f:
     version = f.read().decode('ascii').strip()
@@ -24,7 +22,6 @@ with open(join(dirname(__file__), 'README.md'), 'rb') as f:
     long_description = f.read().decode('utf-8')
 
 requirements = [str(ir.req) for ir in parse_requirements("requirements.txt", session=False)]
-
 
 setup(
     name="jqdatasdk",
@@ -53,5 +50,3 @@ setup(
         'Programming Language :: Python :: 3.6'
     ],
 )
-
-


### PR DESCRIPTION
```
➜  jqdatasdk git:(master) ✗ twine check dist/*                
Checking distribution dist/jqdatasdk-1.4.9-py3-none-any.whl: Failed
The project's long_description has invalid markup which will not be rendered on PyPI. The following syntax errors were detected:
line 36: Warning: Inline literal start-string without end-string.
Checking distribution dist/jqdatasdk-1.4.9.tar.gz: Passed
```

PyPI上的Markdown不能使用空格在一个行前面，加一个点，这样能渲染 Markdown 的 Readme