### PR TITLE
Update finance_service.py

### DIFF
--- a/jqdatasdk/finance_service.py
+++ b/jqdatasdk/finance_service.py
@@ -54,7 +54,7 @@ def get_fundamentals_sql(query_object, date=None, statDate=None):
     else:
         limit = FUNDAMENTAL_RESULT_LIMIT
     offset = query_object.offset_value
-    query_object = query_object.limit(None).limit(None)
+    query_object = query_object.limit(None).offset(None)
 
     tablenames = get_tables_from_sql(str(query_object.statement))
     tables = [get_table_class(name) for name in tablenames]
@@ -163,7 +163,7 @@ def fundamentals_redundant_continuously_query_to_sql(query, trade_day):
     else:
         limit = FUNDAMENTAL_RESULT_LIMIT
     offset = query.offset_value
-    query = query.limit(None).limit(None)
+    query = query.limit(None).offset(None)
 
     def get_table_class(tablename):
         for t in (BalanceSheet, CashFlowStatement, FinancialIndicator,
@@ -217,7 +217,7 @@ def get_continuously_query_to_sql(query, trade_day):
     else:
         limit = FUNDAMENTAL_RESULT_LIMIT
     offset = query.offset_value
-    query = query.limit(None).limit(None)
+    query = query.limit(None).offset(None)
 
     def get_table_class(tablename):
         for t in (BalanceSheet, CashFlowStatement, FinancialIndicator,


### PR DESCRIPTION
Fix the following sqlalchemy error. 

```
get_fundamentals(query(valuation).limit(11).offset(1), date='2021-04-11')

Traceback (most recent call last):
  File "C:\Users\Gabriel\miniconda3\envs\database\lib\site-packages\IPython\core\interactiveshell.py", line 3427, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-4-250f55640757>", line 1, in <module>
    get_fundamentals(query(valuation).limit(11).offset(1), date='2021-04-11')
  File "C:\Users\Gabriel\miniconda3\envs\database\lib\site-packages\jqdatasdk\utils.py", line 255, in _wrapper
    return func(*args, **kwargs)
  File "C:\Users\Gabriel\miniconda3\envs\database\lib\site-packages\jqdatasdk\api.py", line 87, in get_fundamentals
    sql = get_fundamentals_sql(query_object, date, statDate)
  File "C:\Users\Gabriel\miniconda3\envs\database\lib\site-packages\jqdatasdk\finance_service.py", line 113, in get_fundamentals_sql
    query_object = query_object.filter(table.day == date)
  File "<string>", line 2, in filter
  File "C:\Users\Gabriel\miniconda3\envs\database\lib\site-packages\sqlalchemy\orm\base.py", line 226, in generate
    assertion(self, fn.__name__)
  File "C:\Users\Gabriel\miniconda3\envs\database\lib\site-packages\sqlalchemy\orm\query.py", line 517, in _no_limit_offset
    raise sa_exc.InvalidRequestError(
sqlalchemy.exc.InvalidRequestError: Query.filter() being called on a Query which already has LIMIT or OFFSET applied. To modify the row-limited results of a  Query, call from_self() first.  Otherwise, call filter() before limit() or offset() are applied.

```